### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/XAI-liacs/LLaMEA/security/code-scanning/1](https://github.com/XAI-liacs/LLaMEA/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is sufficient for most steps, including checking out the repository and installing dependencies.
- Additional permissions are not required unless explicitly needed by the workflow.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, as none of the jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
