### PR TITLE
Fix LLaMEA prompt typo and configspace serialization

### DIFF
--- a/llamea/llamea.py
+++ b/llamea/llamea.py
@@ -308,7 +308,7 @@ With code:
 
         if self._random:  # not advised to use, only for debugging purposes
             session_messages = [
-                {"role": "user", "content": self.role_promp + self.task_prompt},
+                {"role": "user", "content": self.role_prompt + self.task_prompt},
             ]
         # Logic to construct the new prompt based on current evolutionary state.
         return session_messages

--- a/llamea/solution.py
+++ b/llamea/solution.py
@@ -115,8 +115,13 @@ class Solution:
         """
         try:
             cs = self.configspace
-            cs = cs.to_serialized_dict()
-        except Exception as e:
+            if hasattr(cs, "to_dict"):
+                cs = cs.to_dict()
+            elif hasattr(cs, "to_json"):
+                cs = cs.to_json()
+            else:
+                cs = str(cs)
+        except Exception:
             cs = ""
         return {
             "id": self.id,


### PR DESCRIPTION
## Summary
- fix typo in `_random` prompt construction
- export configspace objects using available `to_dict`/`to_json` methods

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ada95a1c48321a9cf3bda8335e6db