### PR TITLE
Fix example script by removing unused variable

### DIFF
--- a/example.py
+++ b/example.py
@@ -55,7 +55,6 @@ if __name__ == "__main__":
 
                         auc = correct_aoc(problem, l2, budget)
                         aucs.append(auc)
-                        detail_aucs.append(auc)
                         l2.reset(problem)
                         problem.reset()
         auc_mean = np.mean(aucs)


### PR DESCRIPTION
## Summary
- tidy example script by removing reference to undefined `detail_aucs`

## Testing
- `python example.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ade76ede48321ae10dffc2ed8c76e