### PR TITLE
Add configurable log file path for logreader

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,21 @@ python example_AutoML.py
 > [!Note]
 > Adjust the model name (`ai_model`) or API key as needed in the script.
 
+### Viewing conversation logs
+
+The repository provides a minimal Flask app in `logreader/app.py` to explore
+conversation logs stored as JSON Lines files. Start the server with a log file
+path:
+
+```bash
+python logreader/app.py --logfile path/to/conversationlog.jsonl
+```
+
+You can also set the environment variable `CONVERSATION_LOG` instead of passing
+`--logfile`. If neither is given, the app defaults to `conversationlog.jsonl` in
+the current working directory. Navigate to `http://localhost:5001` to browse the
+messages.
+
 ---
 
 ## 🤖 Contributing

--- a/logreader/app.py
+++ b/logreader/app.py
@@ -1,15 +1,29 @@
 import os
+import argparse
 from datetime import datetime
 
 import jsonlines
 from flask import Flask, render_template, request
 from flask_socketio import SocketIO, emit
 
+parser = argparse.ArgumentParser(description="Conversation log viewer")
+parser.add_argument(
+    "--logfile",
+    "-l",
+    default=None,
+    help="Path to the conversation log (.jsonl) file. Can also be set via CONVERSATION_LOG",
+)
+args, _ = parser.parse_known_args()
+
+# Determine path to the jsonlines file
+MESSAGES_FILE = (
+    args.logfile
+    or os.environ.get("CONVERSATION_LOG")
+    or os.path.join(os.getcwd(), "conversationlog.jsonl")
+)
+
 app = Flask(__name__)
 socketio = SocketIO(app)
-
-# Path to the jsonlines file
-MESSAGES_FILE = "/home/neocortex/repos/LLaMEA/exp-08-09_095316-codellama_7b-ES pop5-8/conversationlog.jsonl"
 
 
 @app.route("/")


### PR DESCRIPTION
## Summary
- make the log reader accept a path via `--logfile` argument or `CONVERSATION_LOG` environment variable
- default log file path to `conversationlog.jsonl` in current directory
- document how to use the log reader in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ade39f7dc8321bda2b64f480db903