### PR TITLE
Remove polars import from example_AutoML

### DIFF
--- a/example_AutoML.py
+++ b/example_AutoML.py
@@ -16,7 +16,6 @@ import traceback
 
 import numpy as np
 import pandas as pd
-import polars as pl
 import sklearn
 from sklearn.datasets import load_breast_cancer
 from sklearn.metrics import accuracy_score


### PR DESCRIPTION
## Summary
- delete unused `polars` import from `example_AutoML.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ae21639fc8321ab4bbb22268355a9