### PR TITLE
feat: add adaptive prompt co-evolution

### DIFF
--- a/llamea/solution.py
+++ b/llamea/solution.py
@@ -19,6 +19,7 @@ class Solution:
         generation=0,
         parent_ids=[],
         operator=None,
+        task_prompt="",
     ):
         """
         Initializes an individual with optional attributes.
@@ -31,6 +32,7 @@ class Solution:
             generation (int): The generation this individual belongs to.
             parent_ids (list): UUID of the parent individuals in a list.
             operator (str): Optional identifier of the LLM operation that created this individual.
+            task_prompt (str): The task prompt used to generate this solution.
         """
         self.id = str(uuid.uuid4())  # Unique ID for this individual
         self.code = code
@@ -44,6 +46,7 @@ class Solution:
         self.parent_ids = parent_ids
         self.metadata = {}  # Dictionary to store additional metadata
         self.operator = operator
+        self.task_prompt = task_prompt
 
     def set_operator(self, operator):
         """
@@ -102,6 +105,7 @@ class Solution:
             generation=self.generation + 1,
             parent_ids=[self.id],  # Link this solution as the parent
             operator=self.operator,
+            task_prompt=self.task_prompt,
         )
         new_solution.metadata = self.metadata.copy()  # Copy the metadata as well
         return new_solution
@@ -131,6 +135,7 @@ class Solution:
             "parent_ids": self.parent_ids,
             "operator": self.operator,
             "metadata": self.metadata,
+            "task_prompt": self.task_prompt,
         }
 
     def to_json(self):

--- a/tests/test_adaptive_prompt.py
+++ b/tests/test_adaptive_prompt.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+from llamea.llamea import LLaMEA
+from llamea.solution import Solution
+
+
+def f(individual, logger=None):
+    individual.set_scores(1.0, "ok")
+    return individual
+
+
+class DummyLLM:
+    def __init__(self):
+        self.model = "dummy"
+        self.query = MagicMock(return_value="Refined prompt")
+        self.sample_solution = MagicMock(
+            return_value=Solution(
+                code="class Algo:\n    pass", name="Algo", description="desc"
+            )
+        )
+
+
+def test_adaptive_prompt_updates_task_prompt():
+    llm = DummyLLM()
+    optimizer = LLaMEA(
+        f,
+        llm=llm,
+        n_parents=1,
+        n_offspring=1,
+        adaptive_prompt=True,
+        log=False,
+    )
+
+    individual = Solution(
+        code="class Base:\n    pass",
+        name="Base",
+        task_prompt="Original prompt",
+    )
+    individual.feedback = "Needs work"
+
+    evolved = optimizer.evolve_solution(individual)
+
+    assert evolved.task_prompt == "Refined prompt"
+    llm.query.assert_called_once()
+    session = llm.sample_solution.call_args[0][0]
+    assert "Refined prompt" in session[0]["content"]

--- a/tests/test_individual.py
+++ b/tests/test_individual.py
@@ -25,6 +25,7 @@ def test_individual_initialization():
     assert individual.fitness == -np.inf  # Default should be -Inf
     assert individual.feedback == ""  # Default should be empty string
     assert individual.error == ""  # Default should be empty string
+    assert individual.task_prompt == ""  # Default task prompt
 
 
 def test_add_metadata():
@@ -60,6 +61,7 @@ def test_copy_individual():
     assert new_individual.name == individual.name
     assert new_individual.description == individual.description
     assert new_individual.metadata == individual.metadata  # Metadata should be copied
+    assert new_individual.task_prompt == individual.task_prompt
 
 
 def test_to_dict():
@@ -81,6 +83,7 @@ def test_to_dict():
     assert individual_dict["generation"] == 1
     assert "metadata" in individual_dict
     assert individual_dict["metadata"] == {"source": "LLM-generated"}
+    assert individual_dict["task_prompt"] == ""
 
 
 def test_to_json():
@@ -105,6 +108,7 @@ def test_to_json():
     assert individual_dict["description"] == "This is a test solution."
     assert individual_dict["generation"] == 1
     assert individual_dict["metadata"] == {"source": "LLM-generated"}
+    assert individual_dict["task_prompt"] == ""
 
 
 def test_mutation():
@@ -129,3 +133,4 @@ def test_default_values():
     assert individual.error == ""
     assert individual.parent_ids == []
     assert individual.metadata == {}
+    assert individual.task_prompt == ""


### PR DESCRIPTION
## Summary
- allow solutions to carry and serialize their own task prompt
- add `adaptive_prompt` flag to evolve prompts alongside code
- query the LLM to optimize the task prompt before each mutation

## Testing
- `python -m black llamea/solution.py llamea/llamea.py tests/test_individual.py`
- `isort llamea/solution.py llamea/llamea.py tests/test_individual.py --profile black --check-only`
- `pytest tests/test_individual.py`


------
https://chatgpt.com/codex/tasks/task_e_68945f71bfe48321aa71359310309848