### PR TITLE
feat: add configurable niching strategies

### DIFF
--- a/llamea/__init__.py
+++ b/llamea/__init__.py
@@ -2,4 +2,4 @@ from .llamea import LLaMEA
 from .llm import LLM, Dummy_LLM, Gemini_LLM, Ollama_LLM, OpenAI_LLM
 from .loggers import ExperimentLogger
 from .solution import Solution
-from .utils import NoCodeException, discrete_power_law_distribution
+from .utils import NoCodeException, code_distance, discrete_power_law_distribution

--- a/llamea/llamea.py
+++ b/llamea/llamea.py
@@ -9,6 +9,7 @@ import os
 import random
 import re
 import traceback
+from typing import Callable, Optional
 
 import numpy as np
 from ConfigSpace import ConfigurationSpace
@@ -16,7 +17,12 @@ from joblib import Parallel, delayed
 
 from .loggers import ExperimentLogger
 from .solution import Solution
-from .utils import NoCodeException, discrete_power_law_distribution, handle_timeout
+from .utils import (
+    NoCodeException,
+    code_distance,
+    discrete_power_law_distribution,
+    handle_timeout,
+)
 
 # TODOs:
 # Implement diversity selection mechanisms (none, prefer short code, update population only when (distribution of) results is different, AST / code difference)
@@ -57,6 +63,11 @@ class LLaMEA:
         log=True,
         minimization=False,
         _random=False,
+        niching: Optional[str] = None,
+        distance_metric: Optional[Callable[[Solution, Solution], float]] = None,
+        niche_radius: Optional[float] = None,
+        adaptive_niche_radius: bool = False,
+        clearing_interval: Optional[int] = None,
     ):
         """
         Initializes the LLaMEA instance with provided parameters. Note that by default LLaMEA maximizes the objective.
@@ -85,6 +96,18 @@ class LLaMEA:
             log (bool): Flag to switch of the logging of experiments.
             minimization (bool): Whether we minimize or maximize the objective function. Defaults to False.
             _random (bool): Flag to switch to random search (purely for debugging).
+            niching (str | None): Niching strategy to use. Supports "sharing" and
+                "clearing". If ``None``, niching is disabled.
+            distance_metric (callable | None): Function that computes a distance
+                between two :class:`Solution` objects. Defaults to a simple AST
+                based distance if not supplied.
+            niche_radius (float | None): Radius for niche determination when
+                using fitness sharing or clearing. If ``None`` a default of ``0.5``
+                is used when a niching method is active.
+            adaptive_niche_radius (bool): If ``True`` the niche radius adapts to
+                the population each generation.
+            clearing_interval (int | None): Interval (in generations) at which
+                clearing is applied when ``niching`` is set to ``"clearing"``.
         """
         self.llm = llm
         self.model = llm.model
@@ -173,6 +196,11 @@ Space: <configuration_space>"""
         self.worst_value = -np.Inf
         if minimization:
             self.worst_value = np.Inf
+        self.niching = niching
+        self.distance_metric = distance_metric or code_distance
+        self.niche_radius = niche_radius if niche_radius is not None else 0.5
+        self.adaptive_niche_radius = adaptive_niche_radius
+        self.clearing_interval = clearing_interval
         self.best_so_far = Solution(name="", code="")
         self.best_so_far.set_scores(self.worst_value, "", "")
         self.experiment_name = experiment_name
@@ -332,6 +360,53 @@ With code:
             if best_individual.fitness < self.best_so_far.fitness:
                 self.best_so_far = best_individual
 
+    def adapt_niche_radius(self, population):
+        """Adapt the niche radius based on the current population."""
+        if not self.adaptive_niche_radius or len(population) < 2:
+            return
+        dists = []
+        for i in range(len(population)):
+            for j in range(i + 1, len(population)):
+                dists.append(self.distance_metric(population[i], population[j]))
+        if dists:
+            self.niche_radius = float(np.mean(dists))
+
+    def apply_niching(self, population):
+        """Apply the configured niching strategy to ``population``."""
+        if self.niching not in {"sharing", "clearing"}:
+            return population
+
+        self.adapt_niche_radius(population)
+
+        if self.niching == "sharing":
+            for i, ind in enumerate(population):
+                niche_count = 1.0
+                for j, other in enumerate(population):
+                    if i == j:
+                        continue
+                    d = self.distance_metric(ind, other)
+                    if d < self.niche_radius and self.niche_radius > 0:
+                        niche_count += 1 - d / self.niche_radius
+                if self.minimization:
+                    ind.fitness *= niche_count
+                else:
+                    ind.fitness /= niche_count
+        elif self.niching == "clearing":
+            if self.clearing_interval and self.generation % self.clearing_interval != 0:
+                return population
+            reverse = self.minimization == False
+            population.sort(key=lambda x: x.fitness, reverse=reverse)
+            niches = []
+            for ind in population:
+                if all(
+                    self.distance_metric(ind, winner) >= self.niche_radius
+                    for winner in niches
+                ):
+                    niches.append(ind)
+                else:
+                    ind.fitness = self.worst_value
+        return population
+
     def selection(self, parents, offspring):
         """
         Select the new population based on the parents and the offspring and the current strategy.
@@ -344,19 +419,15 @@ With code:
             list: List of new selected population.
         """
         reverse = self.minimization == False
-
         # TODO filter out non-diverse solutions
         if self.elitism:
-            # Combine parents and offspring
             combined_population = parents + offspring
-            # Sort by fitness
+            combined_population = self.apply_niching(combined_population)
             combined_population.sort(key=lambda x: x.fitness, reverse=reverse)
-            # Select the top individuals to form the new population
             new_population = combined_population[: self.n_parents]
         else:
-            # Sort offspring by fitness
+            offspring = self.apply_niching(list(offspring))
             offspring.sort(key=lambda x: x.fitness, reverse=reverse)
-            # Select the top individuals from offspring to form the new population
             new_population = offspring[: self.n_parents]
 
         return new_population

--- a/llamea/utils.py
+++ b/llamea/utils.py
@@ -1,3 +1,6 @@
+import ast
+from difflib import SequenceMatcher
+
 import numpy as np
 
 
@@ -38,3 +41,30 @@ def discrete_power_law_distribution(n, beta):
     else:
         sample = np.random.choice(elements, p=probabilities)
         return sample / n
+
+
+def code_distance(a, b):
+    """Return a rough distance between two solutions based on their ASTs.
+
+    The function accepts either :class:`Solution` objects or raw code strings
+    and computes ``1 - similarity`` of their abstract syntax trees using
+    :class:`difflib.SequenceMatcher` on the dumped AST representations.
+    ``1.0`` is returned on parsing errors or when the inputs cannot be
+    processed.
+
+    Args:
+        a: The first solution or Python source code.
+        b: The second solution or Python source code.
+
+    Returns:
+        float: A value in ``[0, 1]`` indicating dissimilarity of the code.
+    """
+
+    code_a = getattr(a, "code", a)
+    code_b = getattr(b, "code", b)
+    try:
+        tree_a = ast.parse(code_a)
+        tree_b = ast.parse(code_b)
+        return 1 - SequenceMatcher(None, ast.dump(tree_a), ast.dump(tree_b)).ratio()
+    except Exception:
+        return 1.0

--- a/tests/test_niching.py
+++ b/tests/test_niching.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytest
+
+from llamea.llamea import LLaMEA
+from llamea.solution import Solution
+from llamea.utils import code_distance
+
+
+class DummyLLM:
+    model = "dummy"
+
+
+def identity_f(individual, logger=None):
+    return individual
+
+
+def make_solution(code: str, fitness: float) -> Solution:
+    ind = Solution(code=code)
+    ind.set_scores(fitness)
+    return ind
+
+
+def test_fitness_sharing_reduces_fitness_for_similar_individuals():
+    optimizer = LLaMEA(
+        f=identity_f,
+        llm=DummyLLM(),
+        niching="sharing",
+        niche_radius=1.0,
+        log=False,
+    )
+    s1 = make_solution("a=1", 10.0)
+    s2 = make_solution("a=1", 20.0)
+    optimizer.apply_niching([s1, s2])
+    assert s1.fitness == pytest.approx(5.0)
+    assert s2.fitness == pytest.approx(10.0)
+
+
+def test_clearing_sets_inferior_individual_fitness_to_worst_value():
+    optimizer = LLaMEA(
+        f=identity_f,
+        llm=DummyLLM(),
+        niching="clearing",
+        niche_radius=1.0,
+        clearing_interval=1,
+        log=False,
+    )
+    best = make_solution("a=1", 10.0)
+    worst = make_solution("a=1", 5.0)
+    optimizer.apply_niching([best, worst])
+    assert best.fitness == pytest.approx(10.0)
+    assert np.isneginf(worst.fitness)
+
+
+def test_adaptive_niche_radius_updates_to_mean_distance():
+    optimizer = LLaMEA(
+        f=identity_f,
+        llm=DummyLLM(),
+        niching="sharing",
+        niche_radius=0.5,
+        adaptive_niche_radius=True,
+        log=False,
+    )
+    s1 = make_solution("a=1", 1.0)
+    s2 = make_solution("b=1", 1.0)
+    expected = code_distance("a=1", "b=1")
+    optimizer.apply_niching([s1, s2])
+    assert optimizer.niche_radius == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- add optional fitness sharing and clearing to maintain population diversity
- expose `code_distance` for AST-based dissimilarity measures
- allow adaptive niche radii and clearing intervals through new hyperparameters
- cover fitness sharing, clearing, and adaptive radius with unit tests

## Testing
- `uv run isort --check-only --profile black -v tests/test_niching.py`
- `uv run black --check tests/test_niching.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893027257708321ad17deae5f9330b2