### PR TITLE
Add diff patch generation option

### DIFF
--- a/llamea/utils.py
+++ b/llamea/utils.py
@@ -1,4 +1,5 @@
 import ast
+import re
 from difflib import SequenceMatcher
 
 import numpy as np
@@ -13,6 +14,52 @@ class NoCodeException(Exception):
 def handle_timeout(signum, frame):
     """Raise a timeout exception"""
     raise TimeoutError
+
+
+def apply_unified_diff(text: str, diff: str) -> str:
+    """Apply a unified diff patch to ``text`` and return the modified text.
+
+    This utility parses a unified diff (as produced by ``difflib.unified_diff``)
+    and applies the described changes to the given ``text``.
+
+    Args:
+        text: The original string to patch.
+        diff: The unified diff describing the modifications.
+
+    Returns:
+        str: The patched text.
+    """
+
+    text_lines = text.splitlines(keepends=True)
+    result: list[str] = []
+    line_no = 0
+    diff_lines = diff.splitlines()
+    i = 0
+    hunk_re = re.compile(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+    while i < len(diff_lines):
+        line = diff_lines[i]
+        match = hunk_re.match(line)
+        if match:
+            start = int(match.group(1)) - 1
+            result.extend(text_lines[line_no:start])
+            line_no = start
+            i += 1
+            while i < len(diff_lines) and not diff_lines[i].startswith("@@"):
+                diff_line = diff_lines[i]
+                if diff_line.startswith("+"):
+                    result.append(diff_line[1:] + "\n")
+                elif diff_line.startswith("-"):
+                    line_no += 1
+                elif diff_line.startswith(" "):
+                    result.append(text_lines[line_no])
+                    line_no += 1
+                i += 1
+        else:
+            i += 1
+
+    result.extend(text_lines[line_no:])
+    return "".join(result)
 
 
 def discrete_power_law_distribution(n, beta):


### PR DESCRIPTION
## Summary
- allow LLM to produce unified diff patches instead of full code
- add `diff_mode` flag with new diff output format and patch application
- test diff-based mutation and patch application

## Testing
- `uv run black --check llamea/llm.py llamea/utils.py llamea/llamea.py tests/test_llm.py tests/test_algorithm_generation.py`
- `uv run isort --profile black --check-only llamea/llm.py llamea/utils.py llamea/llamea.py tests/test_llm.py tests/test_algorithm_generation.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894f7c1fc58832181c30cdc01986515