### PR TITLE
Warm_start and Initial population implementation.

### DIFF
--- a/docs/llamea.rst
+++ b/docs/llamea.rst
@@ -15,6 +15,16 @@ Recent features include:
   instead of entire source files from the LLM.
 * **Population evaluation** – with ``evaluate_population=True`` the evaluation
   function ``f`` operates on lists of solutions, allowing batch evaluations.
+* **Warm start** - With every iteration LLaMEA archives its latest run, in
+  `<experiment_log_directory>/llamea_config.pkl`. It not have `warm_start`
+  class methods, that takes the path to `<experiment_log_directory>`, restores
+  the latest object and warm starts the program. Using `.run()` on the restored
+  object will continue from where program was quit, and continue updating the
+  provided directory.
+*  **Initial Population** - After a cold start, initialisation of LLaMEA object
+   one can use `.run(<experiment_log_directory>)` to start with latest individual
+   from the run in described in that directory. Make sure to use similar initialisation
+   criteria, as was use in the previous experiment.
 
 Initialization Parameters
 -------------------------
@@ -56,4 +66,3 @@ The most important keyword arguments of :class:`LLaMEA` are summarised below.
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/examples/warm-start-tests.py
+++ b/examples/warm-start-tests.py
@@ -1,8 +1,6 @@
-# This is a minimal example of how to use the LLaMEA algorithm with the Gemini LLM to generate optimization algorithms for the BBOB test suite.
-# We have to define the following components for LLaMEA to work:
-# - An evaluation function that executes the generated code and evaluates its performance.
-# - A task prompt that describes the problem to be solved.
-# - An LLM instance that will generate the code based on the task prompt.
+# This is a test for warm start, that tests both the functionalities of warm-starting:
+#   Warm starting from Pickled file.
+#   Cold starting new instance, and running with latest individual from specified run in archive_path.
 
 import os
 import re
@@ -89,4 +87,28 @@ if __name__ == "__main__":
             budget=100,
         )
 
-print(es.to_json())
+
+    """Declare path to warm start from here, update when necessary"""
+
+    path_to_archive = os.getcwd() + "/exp-08-21_110139-LLaMEA-gemini-1.5-flash-pop1-5"
+    print(f"Dir name = {path_to_archive}")
+
+
+
+    print(es.__dict__)
+    print("----------------------------------------------------")
+    """Simple run first."""
+    es.run()
+
+
+    es.run(path_to_archive)
+    """
+    ^C to exit, after a while, to test warm start, using,
+    then comment `es` initialisation, and `run`, and use `LLaMEA.warm_start` below.
+    Use es2.run for executing run after warm start.
+    """
+
+    es2 = LLaMEA.warm_start(path_to_archive)
+    print(es2.__dict__)
+
+    es2.run()

--- a/examples/warm-start-tests.py
+++ b/examples/warm-start-tests.py
@@ -4,6 +4,7 @@
 
 import os
 import re
+import pickle
 
 import numpy as np
 from ioh import get_problem, logger
@@ -84,31 +85,46 @@ if __name__ == "__main__":
             experiment_name=experiment_name,
             elitism=True,
             HPO=False,
-            budget=100,
+            budget=4,
         )
 
 
-    """Declare path to warm start from here, update when necessary"""
+        """Declare path to warm start from here, update when necessary"""
 
-    path_to_archive = os.getcwd() + "/exp-08-21_110139-LLaMEA-gemini-1.5-flash-pop1-5"
-    print(f"Dir name = {path_to_archive}")
-
-
-
-    print(es.__dict__)
-    print("----------------------------------------------------")
-    """Simple run first."""
-    es.run()
+        path_to_archive = os.getcwd() + "/exp-08-21_110139-LLaMEA-gemini-1.5-flash-pop1-5"
+        print(f"Dir name = {path_to_archive}")
 
 
-    es.run(path_to_archive)
-    """
-    ^C to exit, after a while, to test warm start, using,
-    then comment `es` initialisation, and `run`, and use `LLaMEA.warm_start` below.
-    Use es2.run for executing run after warm start.
-    """
+        for key, value in es.__dict__.items():
+            print(f"{key}: {value}")
+        print("----------------------------------------------------")
+        """Simple run first."""
+        es.run()
 
-    es2 = LLaMEA.warm_start(path_to_archive)
-    print(es2.__dict__)
 
-    es2.run()
+        # es.run(path_to_archive)
+        #
+        # Testing Pickle dumps for all objects.
+
+        print(pickle.dumps(es.llm))
+        print("----------------------------------------------------")
+        print(pickle.dumps(es.logger))
+        print("----------------------------------------------------")
+        print(pickle.dumps(es.logevent))
+        print("----------------------------------------------------")
+        print(pickle.dumps(es.textlog))
+        print("----------------------------------------------------")
+        # pickle.dumps(es.sol)
+
+        pickle.dumps(evaluateBBOB)
+
+        """
+        ^C to exit, after a while, to test warm start, using,
+        then comment `es` initialisation, and `run`, and use `LLaMEA.warm_start` below.
+        Use es2.run for executing run after warm start.
+        """
+
+        # es2 = LLaMEA.warm_start(path_to_archive)
+        # print(es2.__dict__)
+
+        # es2.run()

--- a/examples/warm-start-tests.py
+++ b/examples/warm-start-tests.py
@@ -76,17 +76,17 @@ if __name__ == "__main__":
 
     for experiment_i in [1]:
         # A 1+1 strategy
-        # es = LLaMEA(
-        #     evaluateBBOB,
-        #     n_parents=1,
-        #     n_offspring=1,
-        #     llm=llm,
-        #     task_prompt=task_prompt,
-        #     experiment_name=experiment_name,
-        #     elitism=True,
-        #     HPO=False,
-        #     budget=400,
-        # )
+        es = LLaMEA(
+            evaluateBBOB,
+            n_parents=1,
+            n_offspring=1,
+            llm=llm,
+            task_prompt=task_prompt,
+            experiment_name=experiment_name,
+            elitism=True,
+            HPO=False,
+            budget=400,
+        )
 
         """Simple run first.
         Hit ^C, before ending execution, and end program prematurely.

--- a/examples/warm-start-tests.py
+++ b/examples/warm-start-tests.py
@@ -9,7 +9,7 @@ import pickle
 import numpy as np
 from ioh import get_problem, logger
 
-from llamea import Gemini_LLM, LLaMEA, ExperimentLogger
+from llamea import Dummy_LLM, LLaMEA, ExperimentLogger
 from misc import OverBudgetException, aoc_logger, correct_aoc
 
 if __name__ == "__main__":
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     api_key = os.getenv("GEMINI_API_KEY")
     ai_model = "gemini-1.5-flash"
     experiment_name = "pop1-5"
-    llm = Gemini_LLM(api_key, ai_model)
+    llm = Dummy_LLM()
 
     # We define the evaluation function that executes the generated algorithm (solution.code) on the BBOB test suite.
     # It should set the scores and feedback of the solution based on the performance metric, in this case we use mean AOCC.
@@ -76,55 +76,36 @@ if __name__ == "__main__":
 
     for experiment_i in [1]:
         # A 1+1 strategy
-        es = LLaMEA(
-            evaluateBBOB,
-            n_parents=1,
-            n_offspring=1,
-            llm=llm,
-            task_prompt=task_prompt,
-            experiment_name=experiment_name,
-            elitism=True,
-            HPO=False,
-            budget=4,
-        )
+        # es = LLaMEA(
+        #     evaluateBBOB,
+        #     n_parents=1,
+        #     n_offspring=1,
+        #     llm=llm,
+        #     task_prompt=task_prompt,
+        #     experiment_name=experiment_name,
+        #     elitism=True,
+        #     HPO=False,
+        #     budget=400,
+        # )
 
-
-        """Declare path to warm start from here, update when necessary"""
-
-        path_to_archive = os.getcwd() + "/exp-08-21_110139-LLaMEA-gemini-1.5-flash-pop1-5"
-        print(f"Dir name = {path_to_archive}")
-
-
-        for key, value in es.__dict__.items():
-            print(f"{key}: {value}")
-        print("----------------------------------------------------")
-        """Simple run first."""
+        """Simple run first.
+        Hit ^C, before ending execution, and end program prematurely.
+        Then comment following line"""
         es.run()
 
-
-        # es.run(path_to_archive)
-        #
-        # Testing Pickle dumps for all objects.
-
-        print(pickle.dumps(es.llm))
-        print("----------------------------------------------------")
-        print(pickle.dumps(es.logger))
-        print("----------------------------------------------------")
-        print(pickle.dumps(es.logevent))
-        print("----------------------------------------------------")
-        print(pickle.dumps(es.textlog))
-        print("----------------------------------------------------")
-        # pickle.dumps(es.sol)
-
-        pickle.dumps(evaluateBBOB)
+        """Declare path to warm start from here, the path where the above quitted program was logging."""
+        path_to_archive = os.getcwd() + "/exp-08-22_110651-LLaMEA-DUMMY-pop1-5"
+        print(f"Dir name = {path_to_archive}")
 
         """
-        ^C to exit, after a while, to test warm start, using,
-        then comment `es` initialisation, and `run`, and use `LLaMEA.warm_start` below.
-        Use es2.run for executing run after warm start.
+        Use `warm_start` class function, which returns the qutting instance of previous object if success, else
+        return None.
         """
 
-        # es2 = LLaMEA.warm_start(path_to_archive)
-        # print(es2.__dict__)
-
-        # es2.run()
+        try:
+            es2 = LLaMEA.warm_start(path_to_archive)
+            for key, value in es2.__dict__.items():
+                print(key, ":", value)
+            es2.run()
+        except Exception as e:
+            print(f"Error un-arciving. {e.__repr__()}")

--- a/examples/warm-start-tests.py
+++ b/examples/warm-start-tests.py
@@ -1,0 +1,92 @@
+# This is a minimal example of how to use the LLaMEA algorithm with the Gemini LLM to generate optimization algorithms for the BBOB test suite.
+# We have to define the following components for LLaMEA to work:
+# - An evaluation function that executes the generated code and evaluates its performance.
+# - A task prompt that describes the problem to be solved.
+# - An LLM instance that will generate the code based on the task prompt.
+
+import os
+import re
+
+import numpy as np
+from ioh import get_problem, logger
+
+from llamea import Gemini_LLM, LLaMEA, ExperimentLogger
+from misc import OverBudgetException, aoc_logger, correct_aoc
+
+if __name__ == "__main__":
+    # Execution code starts here
+    api_key = os.getenv("GEMINI_API_KEY")
+    ai_model = "gemini-1.5-flash"
+    experiment_name = "pop1-5"
+    llm = Gemini_LLM(api_key, ai_model)
+
+    # We define the evaluation function that executes the generated algorithm (solution.code) on the BBOB test suite.
+    # It should set the scores and feedback of the solution based on the performance metric, in this case we use mean AOCC.
+    def evaluateBBOB(solution, explogger=None):
+        auc_mean = 0
+        auc_std = 0
+
+        code = solution.code
+        algorithm_name = solution.name
+        exec(code, globals())
+
+        error = ""
+
+        aucs = []
+
+        algorithm = None
+        for dim in [5]:
+            budget = 2000 * dim
+            l2 = aoc_logger(budget, upper=1e2, triggers=[logger.trigger.ALWAYS])
+            for fid in np.arange(1, 25):
+                for iid in [1, 2, 3]:  # , 4, 5]
+                    problem = get_problem(fid, iid, dim)
+                    problem.attach_logger(l2)
+
+                    for rep in range(3):
+                        np.random.seed(rep)
+                        try:
+                            algorithm = globals()[algorithm_name](
+                                budget=budget, dim=dim
+                            )
+                            algorithm(problem)
+                        except OverBudgetException:
+                            pass
+
+                        auc = correct_aoc(problem, l2, budget)
+                        aucs.append(auc)
+                        l2.reset(problem)
+                        problem.reset()
+        auc_mean = np.mean(aucs)
+        auc_std = np.std(aucs)
+
+        feedback = f"The algorithm {algorithm_name} got an average Area over the convergence curve (AOCC, 1.0 is the best) score of {auc_mean:0.2f} with standard deviation {auc_std:0.2f}."
+
+        print(algorithm_name, algorithm, auc_mean, auc_std)
+        solution.add_metadata("aucs", aucs)
+        solution.set_scores(auc_mean, feedback)
+
+        return solution
+
+    # The task prompt describes the problem to be solved by the LLaMEA algorithm.
+    task_prompt = """
+    The optimization algorithm should handle a wide range of tasks, which is evaluated on the BBOB test suite of 24 noiseless functions. Your task is to write the optimization algorithm in Python code. The code should contain an `__init__(self, budget, dim)` function and the function `def __call__(self, func)`, which should optimize the black box function `func` using `self.budget` function evaluations.
+    The func() can only be called as many times as the budget allows, not more. Each of the optimization functions has a search space between -5.0 (lower bound) and 5.0 (upper bound). The dimensionality can be varied.
+    Give an excellent and novel heuristic algorithm to solve this task and also give it a one-line description with the main idea.
+    """
+
+    for experiment_i in [1]:
+        # A 1+1 strategy
+        es = LLaMEA(
+            evaluateBBOB,
+            n_parents=1,
+            n_offspring=1,
+            llm=llm,
+            task_prompt=task_prompt,
+            experiment_name=experiment_name,
+            elitism=True,
+            HPO=False,
+            budget=100,
+        )
+
+print(es.to_json())

--- a/llamea/llamea.py
+++ b/llamea/llamea.py
@@ -246,10 +246,14 @@ markdown code block labelled as diff:
         self.pickle_archieve()
 
     def __getstate__(self):
-        return self.__dict__
+        state = self.__dict__.copy()
+        state.pop("textlog", None)
+        return state
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        # Logging object often has open f stream, which is not piklable.
+        self.textlog = logging.getLogger(__name__)
 
     @classmethod
     def warm_start(cls, path_to_archive_dir):
@@ -264,8 +268,8 @@ markdown code block labelled as diff:
                 obj = pickle.load(file)
             return obj
         except Exception as e:
-            print("Error unarchiving object", e.__repr__())
-            return 1
+            print(f"Error unarchiving object from {f"{path_to_archive_dir}/llamea_config.pkl"}: {e.__repr__()}")
+            return None
 
     def logevent(self, event):
         self.textlog.info(event)
@@ -687,7 +691,6 @@ With code:
         try:
             with open(f"{self.logger.dirname}/llamea_config.pkl", "wb") as file:
                 pickle.dump(self, file)
-                pickletools.dis(data)
         except Exception as e:
             self.textlog.error("Error archiving LLaMEA object: " + e.__repr__())
             traceback.print_exc()

--- a/llamea/llm.py
+++ b/llamea/llm.py
@@ -215,29 +215,6 @@ class LLM(ABC):
         else:
             return ""
 
-    def to_serialisable_dict(self):
-        """
-        Generate a json object for implementing warm start.
-
-        Args:
-            None.
-
-        Returns:
-            json object with of all the variables.
-        """
-        properties = {}
-        # get all attributes from instance
-
-        for member, value in self.__dict__.items():
-            # check if this member is defined in Base, not only in Child
-            if isinstance(value, ExperimentLogger):
-                properties[member+"::ExperimentLogger"] = value.to_serialisable_dict()
-            else:
-                properties[member] = value
-        properties.pop('client')
-        return properties
-
-
 class OpenAI_LLM(LLM):
     """
     A manager class for handling requests to OpenAI's GPT models.

--- a/llamea/loggers.py
+++ b/llamea/loggers.py
@@ -122,15 +122,3 @@ class ExperimentLogger:
             else:
                 file.write("Failed to extract config space")
         self.attempt = attempt
-
-    def to_serialisable_dict(self):
-        """
-        Generates json of current instance, used for warm starting as ExperimentLogger is used in LLaMEA.
-
-        Args:
-            None.
-        """
-        properties = {}
-        for member, value in vars(self).items():
-            properties[member] = convert_to_serializable(value)
-        return properties

--- a/llamea/loggers.py
+++ b/llamea/loggers.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 
 import jsonlines
-import json
 import numpy as np
 from ConfigSpace.read_and_write import json as cs_json
 
@@ -33,6 +32,7 @@ class ExperimentLogger:
         Args:
             name (str): The name of the experiment.
         """
+        self.working_date = datetime.today().strftime("%m-%d_%H%M%S")
         self.dirname = self.create_log_dir(name)
         self.attempt = 0
 
@@ -50,8 +50,9 @@ class ExperimentLogger:
         Returns:
             str: The name of the created directory.
         """
+        print("Experiment Logger: ", self.__dict__)
         model_name = name.split("/")[-1]
-        today = datetime.today().strftime("%m-%d_%H%M%S")
+        today = self.working_date
         dirname = f"exp-{today}-{name}"
         os.mkdir(dirname)
         os.mkdir(f"{dirname}/configspace")

--- a/llamea/loggers.py
+++ b/llamea/loggers.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 
 import jsonlines
+import json
 import numpy as np
 from ConfigSpace.read_and_write import json as cs_json
 
@@ -121,3 +122,15 @@ class ExperimentLogger:
             else:
                 file.write("Failed to extract config space")
         self.attempt = attempt
+
+    def to_serialisable_dict(self):
+        """
+        Generates json of current instance, used for warm starting as ExperimentLogger is used in LLaMEA.
+
+        Args:
+            None.
+        """
+        properties = {}
+        for member, value in vars(self).items():
+            properties[member] = convert_to_serializable(value)
+        return properties

--- a/llamea/loggers.py
+++ b/llamea/loggers.py
@@ -36,6 +36,12 @@ class ExperimentLogger:
         self.dirname = self.create_log_dir(name)
         self.attempt = 0
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def create_log_dir(self, name=""):
         """
         Creates a new directory for logging experiments based on the current date and time.

--- a/llamea/loggers.py
+++ b/llamea/loggers.py
@@ -50,7 +50,6 @@ class ExperimentLogger:
         Returns:
             str: The name of the created directory.
         """
-        print("Experiment Logger: ", self.__dict__)
         model_name = name.split("/")[-1]
         today = self.working_date
         dirname = f"exp-{today}-{name}"

--- a/llamea/solution.py
+++ b/llamea/solution.py
@@ -164,6 +164,3 @@ class Solution:
             str: A JSON string representation of the individual.
         """
         return json.dumps(self.to_dict(), default=str, indent=4)
-
-    def to_serialisable_dict(self):
-        return self.to_dict()

--- a/llamea/solution.py
+++ b/llamea/solution.py
@@ -164,3 +164,6 @@ class Solution:
             str: A JSON string representation of the individual.
         """
         return json.dumps(self.to_dict(), default=str, indent=4)
+
+    def to_serialisable_dict(self):
+        return self.to_dict()

--- a/llamea/solution.py
+++ b/llamea/solution.py
@@ -53,6 +53,8 @@ class Solution:
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        if self.configspace == "":
+            self.configspace = None
 
     def set_operator(self, operator):
         """

--- a/llamea/solution.py
+++ b/llamea/solution.py
@@ -48,6 +48,12 @@ class Solution:
         self.operator = operator
         self.task_prompt = task_prompt
 
+    def __getstate__(self):
+        return self.to_dict()
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def set_operator(self, operator):
         """
         Sets the operator name that generated this individual.

--- a/tests/test_archival.py
+++ b/tests/test_archival.py
@@ -1,0 +1,31 @@
+from logging import Logger
+import unittest
+import random
+import time
+
+from llamea import LLaMEA, Dummy_LLM, ExperimentLogger, Solution
+
+def evaluationFunction(solution, explogger=None):
+    return random.random()
+
+class TestArchival(unittest.TestCase):
+
+
+    def test_archival(self):
+        llm = Dummy_LLM()
+        roleprompt = "You are a gamer"
+        task_prompt = "Test prompt. You are asked to pick a number between 1-10, and will get response as to distance between correct and your answer. The correct answer changes every time."
+        # Instantiate an object.
+
+
+        es = LLaMEA(evaluationFunction, llm, n_parents=1, task_prompt=task_prompt, role_prompt=roleprompt, budget=200)
+        dirname = es.logger.dirname
+        time.sleep(4)           #Wait for archival to reflect on storage.
+        es_start_archive = LLaMEA.warm_start(dirname) #Warm start.
+
+        archived_es = es_start_archive.__dict__
+        for key, value in es.__dict__.items():
+            if isinstance(value, Logger | ExperimentLogger | Solution | None | Dummy_LLM):      #Objects when resurrected will not have same identifier.
+                pass
+            else:
+                self.assertEqual(archived_es[key], value)


### PR DESCRIPTION
During the execution of the evolutionary loop, the program now `pickles` it's object in `LoggerDir/llamea_config.pkl`.
This allows one to warm start from previously abandoned place.
* To implement warm start, `ExperimentLogger.working_date` was added as a new property, to continue logging in the same directory as the previous--prematurely exited--iteration.
* Added a `classmethod` for warm start, creatively named warm_start that takes in logger dir for which warm start needs to execute. It returns the latest instance of the object from that instance.
* Added a new test case for warm_start, (play around with location of the global function to see when and when does it not fail the program to pickle.
* Added a new parameter to `.run` in `archive_path`, which defaults to `None` to add a cold start option with an initial population.
    * When provided path, it fetches last `min(|population in log.jsonl|, llamea.n_parents)` and initialises remaining population.

