### PR TITLE
Document selection methods

### DIFF
--- a/llamea/llamea.py
+++ b/llamea/llamea.py
@@ -129,6 +129,12 @@ class LLaMEA:
                 `f(population, parents=None, logger=None) -> (evaluated_offspring, evaluated_parents)`.
             diff_mode (bool): If ``True``, the LLM is asked to generate unified diff
                 patches instead of complete code when evolving solutions.
+            parent_selection (str): Strategy for selecting parents to produce
+                offspring. Options are ``"random"``, ``"tournament"``, which
+                picks the best from a sampled subset, and fitness-proportionate
+                roulette wheel selection ``"roulette"``.
+            tournament_size (int): Number of candidates sampled in each
+                tournament when using ``"tournament"`` selection.
         """
         self.llm = llm
         self.model = llm.model


### PR DESCRIPTION
## Summary
- clarify LLaMEA `__init__` docstring to describe tournament and roulette wheel parent selection options

## Testing
- no tests run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68b58975c6188321b7f1303fffe1f715