### PR TITLE
Feature/fixutils

### DIFF
--- a/docs/llamea.rst
+++ b/docs/llamea.rst
@@ -11,8 +11,8 @@ Recent features include:
 * **Niching** – enable ``niching="sharing"`` or ``niching="clearing"`` to
   maintain diversity. ``distance_metric``, ``niche_radius``,
   ``adaptive_niche_radius`` and ``clearing_interval`` further tune the niches.
-* **Unified diff mode** – set ``diff_mode=True`` to request unified diff patches
-  instead of entire source files from the LLM.
+* **Diff mode** – set ``diff_mode=True`` to request SEARCH/REPLACE patches
+  instead of entire source files from the LLM. This is more token efficient for large code bases.
 * **Population evaluation** – with ``evaluate_population=True`` the evaluation
   function ``f`` operates on lists of solutions, allowing batch evaluations.
 * **Warm start** -With every iteration, **LLaMEA** archives its latest run in

--- a/llamea/llm.py
+++ b/llamea/llm.py
@@ -10,9 +10,6 @@ import re
 import time
 from abc import ABC, abstractmethod
 
-from misc.utils import apply_code_delta
-
-
 try:
     import google.generativeai as genai
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
@@ -34,8 +31,7 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
     ConfigurationSpace = None
 
 from .solution import Solution
-from .loggers import ExperimentLogger
-from .utils import NoCodeException, apply_unified_diff
+from .utils import NoCodeException, apply_code_delta
 
 
 class LLM(ABC):

--- a/llamea/llm.py
+++ b/llamea/llm.py
@@ -219,7 +219,15 @@ class LLM(ABC):
         """
         match = re.search(self.code_pattern, message, re.DOTALL | re.IGNORECASE)
         if match:
-            return match.group(1)
+            code = match.group(1)
+            main_guard_pattern = re.compile(
+                r"^\s*if __name__\s*={1,2}\s*['\"]__main__['\"]\s*:\s*$",
+                re.MULTILINE,
+            )
+            guard_match = main_guard_pattern.search(code)
+            if guard_match:
+                code = code[: guard_match.start()].rstrip()
+            return code
         else:
             raise NoCodeException
 

--- a/llamea/utils.py
+++ b/llamea/utils.py
@@ -4,6 +4,7 @@ from difflib import SequenceMatcher
 import numpy as np
 from difflib import SequenceMatcher
 
+
 class NoCodeException(Exception):
     """Could not extract generated code."""
 

--- a/llamea/utils.py
+++ b/llamea/utils.py
@@ -1,11 +1,8 @@
 import ast
 import re
 from difflib import SequenceMatcher
-from typing import List
 import numpy as np
-import subprocess
-import os
-
+from difflib import SequenceMatcher
 
 class NoCodeException(Exception):
     """Could not extract generated code."""
@@ -18,92 +15,76 @@ def handle_timeout(signum, frame):
     raise TimeoutError
 
 
-def apply_unified_diff(text: str, diff: str) -> str:
+def _code_updater(code: str, lines_to_change: list[str], updated_lines: list[str]):
+    """Line by line update code, and return the update.
+    Args:
+        code: Current code in the individual.
+        lines_to_change: A list of lines to be changed by the LLM.
+        updated_lines: Lines to replace the `lines_to_update`.
+
     """
-    Apply a unified diff to the given text using the system `patch` command.
+    if len(lines_to_change) != len(lines_to_change):
+        raise ValueError
+    for i in range(len(lines_to_change)):
+        code = code.replace(
+            lines_to_change[i], updated_lines[i], 1
+        )  # Update one occurance of lines_to_change, to corresponding change.
+    return code
 
-    This delegates all parsing and application logic to the external `patch`
-    utility, which is far more robust than a hand-rolled parser. It handles
-    context mismatches, fuzz factors, and edge cases like missing EOF newlines.
 
-    ```text
-    ┌─────────────┐
-    │   INPUT     │
-    │  text:str   │──┐
-    └─────────────┘  │
-                     ▼
-               ┌───────────┐
-               │ tempfile  │  → holds original text
-               └───────────┘
-                     │
-                     ▼
-              ┌──────────────┐
-              │  patch cmd   │ ← receives unified diff on stdin
-              └──────────────┘
-                     │
-                     ▼
-               ┌───────────┐
-               │ tempfile  │ → now contains patched text
-               └───────────┘
-                     │
-                     ▼
-                patched:str
+def apply_code_delta(text: str, base_code: str) -> tuple[str, bool, float]:
+    """
+    Assuming the LLM follows the intructions properly, following format of response is expected.
+    ```diff <- (diff may appear sometimes.)
+    # A series of following search replace pattern will appear.
+    <<<<<<< SEARCH
+    for i in range(m):
+        for j in range(p):
+            for k in range(n):
+                C[i, j] += A[i, k] * B[k, j]
+    =======
+    # Reorder loops for better memory access pattern
+    for i in range(m):
+        for k in range(n):
+            for j in range(p):
+                C[i, j] += A[i, k] * B[k, j]
+    >>>>>>> REPLACE
     ```
 
     Args:
-        text: The original text to patch.
-        diff: The unified diff (as produced by `git diff`, `difflib.unified_diff`, etc.).
-        strip: Optional `-p` value to pass to `patch` (number of path segments to strip).
-               Useful if the diff contains file paths you want ignored.
-
+        text: LLM response.text.
+        base_code: Base code to be mutated.
     Returns:
-        The patched text as a string.
-
-    Raises:
-        subprocess.CalledProcessError: If `patch` fails and returns a nonzero exit code.
-        FileNotFoundError: If `patch` is not installed.
+        Code: updated code, after applying diff.
+        bool: Success of diff mode implementation.
+        float: Ratio of code changed.
     """
-    import tempfile
-
-    # check that the text ends in a newline
-
-    if not text.endswith("\n"):
-        text += "\n"
-
-    d = diff.lstrip()
-    if not d.startswith("--- "):
-        diff = f"--- a\n+++ a\n{diff}"
-
-    # Ensure diff ends with a newline too
-    if not diff.endswith("\n"):
-        diff += "\n"
-
-    tf = tempfile.NamedTemporaryFile("w+", delete=False)
+    outLines = []
+    inLines = []
     try:
-        tf.write(text)
-        tf.flush()
-        path = tf.name
-    finally:
-        tf.close()  # critical: allow patch to replace the file
-
-    try:
-        proc = subprocess.run(
-            ["patch", "-u", path],
-            input=diff.encode("utf-8"),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        pattern = re.compile(
+            r"(?s)<{3,}\s*SEARCH\s*\n(.*?)\n={3,}\s*\n(.*?)(?=\n>{3,}\s*REPLACE)"
         )
-        # Now read the (possibly replaced) file from disk
-        with open(path, "r", encoding="utf-8") as f:
-            newcode = f.read()
-            # finally, remove the temporary file
-    finally:
-        # Clean up even if patch failed
-        try:
-            os.unlink(path)
-        except FileNotFoundError:
-            pass
-    return newcode
+        matches = pattern.findall(text)
+        if len(matches) == 0:
+            print(
+                "WARNING: LLM didn't adhere to search replace pattern. Try bigger model."
+            )
+            raise ValueError
+
+        for search, replace in matches:
+            outLines.append(search)
+            inLines.append(replace)
+
+        code = _code_updater(base_code, outLines, inLines)
+
+        seq_match = SequenceMatcher(None, code, base_code)
+        ratio = seq_match.ratio()
+
+        return code, True, ratio
+
+    except Exception:
+        return base_code, False, 1.0
 
 
 def discrete_power_law_distribution(n, beta):

--- a/pyproject-lite.toml
+++ b/pyproject-lite.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llamea-lite"
-version = "1.1.6"
+version = "1.1.7"
 description = "LLaMEA without bundled LLM or HPO dependencies"
 authors = [{ name = "Niki van Stein", email = "n.van.stein@liacs.leidenuniv.nl" }]
 requires-python = ">=3.11, <4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llamea"
-version = "1.1.6"
+version = "1.1.7"
 description = "LLaMEA is a Python framework for automatically generating and refining metaheuristic optimization algorithms using large language models, featuring optional in-the-loop hyper-parameter optimization."
 authors = [{ name = "Niki van Stein", email = "n.van.stein@liacs.leidenuniv.nl" }]
 requires-python = ">=3.11, <4"

--- a/tests/test_algorithm_generation.py
+++ b/tests/test_algorithm_generation.py
@@ -52,23 +52,24 @@ def test_evolve_solution_with_diff():
         experiment_name="diff",
         log=False,
         diff_mode=True,
-        evaluate_population=True,
+        evaluate_population=False,
     )
 
     base = Solution(code="class MyAlgo:\n    pass\n", name="MyAlgo", description="d")
     optimizer.population = [base]
-    diff_reply = (
-        "# Description: Modified\n"
-        "```diff\n"
-        "--- original.py\n"
-        "+++ updated.py\n"
-        "@@ -1,2 +1,3 @@\n"
-        " class MyAlgo:\n"
-        "-    pass\n"
-        "+    def run(self):\n"
-        "+        return 42\n"
-        "```"
-    )
+    diff_reply = """
+```
+<<<<<<< SEARCH
+    pass
+=======
+    # Added loops
+    for i in range(m):
+        for k in range(n):
+            for j in range(p):
+                C[i, j] += A[i, k] * B[k, j]
+>>>>>>> REPLACE
+```"""
     optimizer.llm.query = MagicMock(return_value=diff_reply)
     evolved = optimizer.evolve_solution(base)
-    assert "return 42" in evolved.code
+    assert "# Added loops" in evolved.code, evolved.code + " does not contain added code '# Added loops'"
+    assert "pass" not in evolved.code, evolved.code + " contains code 'pass'"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -112,32 +112,25 @@ def test_llm_sample_solution_good_code():
     assert sol.name == "MyAlgo"
     assert "class MyAlgo" in sol.code
 
-
-def test_llm_sample_solution_diff_patch():
+def test_extract_algorithm_code_strips_main_block():
     class DummyLLM(LLM):
-        def query(self, session: list):
-            return (
-                "# Description: Modified\n"
-                "```diff\n"
-                "--- original.py\n"
-                "+++ updated.py\n"
-                "@@ -1,2 +1,3 @@\n"
-                " class MyAlgo:\n"
-                "-    pass\n"
-                "+    def run(self):\n"
-                "+        return 42\n"
-                "```"
-            )
+        def query(self, session: list):  # pragma: no cover - helper for direct method call
+            return ""
 
-    base = "class MyAlgo:\n    pass\n"
     llm = DummyLLM(api_key="x", model="y")
-    sol = llm.sample_solution(
-        [{"role": "client", "content": "test"}],
-        base_code=base,
-        diff_mode=True,
+    message = (
+        "```python\n"
+        "class Foo:\n"
+        "    pass\n\n"
+        "if __name__ == '__main__':\n"
+        "    print('hi')\n"
+        "```"
     )
-    assert "return 42" in sol.code
-    assert sol.name == "MyAlgo"
+
+    code = llm.extract_algorithm_code(message)
+    assert "if __name__" not in code
+    assert "print('hi')" not in code
+
 
 
 def test_openai_llm_init():

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <4"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "llamea"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "configspace" },


### PR DESCRIPTION
The SEARCH/REPLACE implementation was not working as the code recided in the `misc` folder, and this folder is not accessible when you install LLaMEA via pip.

I moved the code to `llamea/utils.py`.

In addition:  
- I updated the old patching tests with the new SEARCH/REPLACE blocks.
- I added functionality to strip __main__ blocks in generated code (this can be re-used in BLADE, please create a separate ticket @anantashahane  and copy paste this functionality to `iohblade/llm.py`.
- I added a unit test for the stripping of main blocks.