### PR TITLE
Apply textwrap.dedent to multi-line prompt strings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,4 +82,4 @@ users needing to override it.
 
 ## Git branch convention
 
-Feature branches follow the pattern `claude/<short-description>-<id>`.
+Feature branches follow the pattern `feature/<short-description>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,14 +23,14 @@ Examples live in `examples/`, benchmarks in `benchmarks/`.
 uv sync --dev
 ```
 
+### Run import sorter (run before black)
+```bash
+uv run isort llamea/
+```
+
 ### Run formatter
 ```bash
 uv run black llamea/
-```
-
-### Run linter (import sorting)
-```bash
-uv run isort llamea/
 ```
 
 ### Run tests
@@ -43,8 +43,8 @@ uv run pytest --cov=llamea
 ### Typical pre-commit sequence
 ```bash
 uv sync --dev
-uv run black llamea/
 uv run isort llamea/
+uv run black llamea/
 uv run pytest
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# LLaMEA – Claude Code Guide
+
+## Repository overview
+
+LLaMEA is a Python framework that drives an evolutionary loop powered by an LLM.
+It generates, evaluates, and refines code (e.g. optimisation algorithms, ML pipelines)
+by prompting the LLM to mutate the current best solution.
+
+Key source files under `llamea/`:
+- `llamea.py` – main `LLaMEA` class; evolutionary loop, prompt construction, default prompts
+- `llm.py` – LLM wrappers (`OpenAI_LLM`, `Gemini_LLM`, `Ollama_LLM`, `Dummy_LLM`, …)
+- `solution.py` – `Solution` dataclass holding code, description, score, feedback
+- `diffmodemanager.py` – applies SEARCH/REPLACE diffs returned by the LLM
+- `feature_guidance.py` – complexity-based mutation guidance
+- `loggers.py` / `utils.py` – experiment logging and helper utilities
+
+Examples live in `examples/`, benchmarks in `benchmarks/`.
+
+## Development workflow
+
+### Install dependencies (always do this first)
+```bash
+uv sync --dev
+```
+
+### Run formatter
+```bash
+uv run black llamea/
+```
+
+### Run linter (import sorting)
+```bash
+uv run isort llamea/
+```
+
+### Run tests
+```bash
+uv run pytest
+# with coverage:
+uv run pytest --cov=llamea
+```
+
+### Typical pre-commit sequence
+```bash
+uv sync --dev
+uv run black llamea/
+uv run isort llamea/
+uv run pytest
+```
+
+## Code conventions
+
+- **Formatter**: `black` (line length default, ~88 chars)
+- **Import order**: `isort` (stdlib → third-party → local)
+- **Python**: ≥ 3.11
+- **Multi-line prompt strings**: wrap with `textwrap.dedent()` to avoid sending
+  accidental leading whitespace to the LLM, e.g.:
+  ```python
+  import textwrap
+  prompt = textwrap.dedent("""
+      Your instructions here.
+      More lines.
+      """)
+  ```
+
+## Prompt architecture
+
+`LLaMEA.__init__` accepts four prompt parameters (all have defaults):
+| Parameter | Purpose |
+|---|---|
+| `role_prompt` | LLM system persona (neutral, task-independent) |
+| `task_prompt` | Problem description; what the LLM should produce |
+| `example_prompt` | Illustrative code example |
+| `output_format_prompt` | Required response format |
+
+A fifth prompt, `diff_output_format_prompt`, is built-in and controls the
+SEARCH/REPLACE diff mode.
+
+The default `role_prompt` is intentionally generic ("You are a highly skilled
+computer scientist and Python expert.") so it works across domains without
+users needing to override it.
+
+## Git branch convention
+
+Feature branches follow the pattern `claude/<short-description>-<id>`.

--- a/examples/black-box-opt-with-HPO.py
+++ b/examples/black-box-opt-with-HPO.py
@@ -8,6 +8,7 @@
 
 import os
 import re
+import textwrap
 import time
 from itertools import product
 
@@ -170,7 +171,7 @@ if __name__ == "__main__":
         return solution
 
     role_prompt = "You are a highly skilled computer scientist in the field of natural computing. Your task is to design novel metaheuristic algorithms to solve black box optimization problems."
-    task_prompt = """
+    task_prompt = textwrap.dedent("""
     The optimization algorithm should handle a wide range of tasks, which is evaluated on the BBOB test suite of 24 noiseless functions. Your task is to write the optimization algorithm in Python code. The code should contain an `__init__(self, budget, dim)` function with optional additional arguments and the function `def __call__(self, func)`, which should optimize the black box function `func` using `self.budget` function evaluations.
     The func() can only be called as many times as the budget allows, not more. Each of the optimization functions has a search space between -5.0 (lower bound) and 5.0 (upper bound). The dimensionality can be varied.
 
@@ -180,22 +181,22 @@ if __name__ == "__main__":
     ```python
     {
         "float_parameter": (0.1, 1.5),
-        "int_parameter": (2, 10), 
+        "int_parameter": (2, 10),
         "categoral_parameter": ["mouse", "cat", "dog"]
     }
     ```
 
-    Give an excellent and novel heuristic algorithm including its configuration space to solve this task and also give it a one-line description, describing the main idea. 
-    """
+    Give an excellent and novel heuristic algorithm including its configuration space to solve this task and also give it a one-line description, describing the main idea.
+    """)
 
-    format_prompt = """
+    format_prompt = textwrap.dedent("""
     Give the response in the format:
     # Description: <short-description>
     # Code: <code>
     # Space: <configuration_space>
-    """
+    """)
 
-    example_prompt = """
+    example_prompt = textwrap.dedent("""
     An example of such code (a simple random search), is as follows:
     ```python
     import numpy as np
@@ -210,15 +211,15 @@ if __name__ == "__main__":
             self.x_opt = None
             for i in range(self.budget):
                 x = np.random.uniform(func.bounds.lb, func.bounds.ub)
-                
+
                 f = func(x)
                 if f < self.f_opt:
                     self.f_opt = f
                     self.x_opt = x
-                
+
             return self.f_opt, self.x_opt
     ```
-    """
+    """)
 
     feedback_prompts = [
         f"Either refine or redesign to improve the solution (and give it a distinct one-line description)."

--- a/examples/black-box-optimization-diff-mode.py
+++ b/examples/black-box-optimization-diff-mode.py
@@ -10,6 +10,7 @@
 #   code replacement, without making new request for that iteration.
 
 import os
+import textwrap
 
 import numpy as np
 from ioh import get_problem, logger
@@ -85,11 +86,11 @@ if __name__ == "__main__":
         return solution
 
     # The task prompt describes the problem to be solved by the LLaMEA algorithm.
-    task_prompt = """
+    task_prompt = textwrap.dedent("""
     The optimization algorithm should handle a wide range of tasks, which is evaluated on the BBOB test suite of 24 noiseless functions. Your task is to write the optimization algorithm in Python code. The code should contain an `__init__(self, budget, dim)` function and the function `def __call__(self, func)`, which should optimize the black box function `func` using `self.budget` function evaluations.
     The func() can only be called as many times as the budget allows, not more. Each of the optimization functions has a search space between -5.0 (lower bound) and 5.0 (upper bound). The dimensionality can be varied.
     Give an excellent and novel heuristic algorithm to solve this task and also give it a one-line description with the main idea.
-    """
+    """)
 
     for experiment_i in [1]:
         # A 1+1 strategy

--- a/examples/black-box-optimization.py
+++ b/examples/black-box-optimization.py
@@ -6,6 +6,7 @@
 
 import os
 import pickle
+import textwrap
 
 import numpy as np
 from ioh import get_problem, logger
@@ -80,11 +81,11 @@ if __name__ == "__main__":
         return solution
 
     # The task prompt describes the problem to be solved by the LLaMEA algorithm.
-    task_prompt = """
+    task_prompt = textwrap.dedent("""
     The optimization algorithm should handle a wide range of tasks, which is evaluated on the BBOB test suite of 24 noiseless functions. Your task is to write the optimization algorithm in Python code. The code should contain an `__init__(self, budget, dim)` function and the function `def __call__(self, func)`, which should optimize the black box function `func` using `self.budget` function evaluations.
     The func() can only be called as many times as the budget allows, not more. Each of the optimization functions has a search space between -5.0 (lower bound) and 5.0 (upper bound). The dimensionality can be varied.
     Give an excellent and novel heuristic algorithm to solve this task and also give it a one-line description with the main idea.
-    """
+    """)
 
     for experiment_i in [1]:
         # A 1+1 strategy

--- a/examples/minimum_example.py
+++ b/examples/minimum_example.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import textwrap
 
 import numpy as np
 
@@ -36,11 +37,11 @@ if __name__ == "__main__":
         return solution
 
     # The task prompt describes the problem to be solved by the LLaMEA algorithm.
-    task_prompt = """
+    task_prompt = textwrap.dedent("""
     The optimization algorithm should handle a wide range of tasks, which is evaluated on the BBOB test suite of 24 noiseless functions. Your task is to write the optimization algorithm in Python code. The code should contain an `__init__(self, budget, dim)` function and the function `def __call__(self, func)`, which should optimize the black box function `func` using `self.budget` function evaluations.
     The func() can only be called as many times as the budget allows, not more. Each of the optimization functions has a search space between -5.0 (lower bound) and 5.0 (upper bound). The dimensionality can be varied.
     Give an excellent and novel heuristic algorithm to solve this task and also give it a one-line description with the main idea. You can only use the numpy (1.26) library, no other libraries are allowed.
-    """
+    """)
     es = LLaMEA(
         evaluate,
         n_parents=1,

--- a/examples/warm-start-tests.py
+++ b/examples/warm-start-tests.py
@@ -5,6 +5,7 @@
 import os
 import re
 import pickle
+import textwrap
 
 import numpy as np
 from ioh import get_problem, logger
@@ -68,11 +69,11 @@ if __name__ == "__main__":
         return solution
 
     # The task prompt describes the problem to be solved by the LLaMEA algorithm.
-    task_prompt = """
+    task_prompt = textwrap.dedent("""
     The optimization algorithm should handle a wide range of tasks, which is evaluated on the BBOB test suite of 24 noiseless functions. Your task is to write the optimization algorithm in Python code. The code should contain an `__init__(self, budget, dim)` function and the function `def __call__(self, func)`, which should optimize the black box function `func` using `self.budget` function evaluations.
     The func() can only be called as many times as the budget allows, not more. Each of the optimization functions has a search space between -5.0 (lower bound) and 5.0 (upper bound). The dimensionality can be varied.
     Give an excellent and novel heuristic algorithm to solve this task and also give it a one-line description with the main idea.
-    """
+    """)
 
     for experiment_i in [1]:
         # A 1+1 strategy

--- a/llamea/llamea.py
+++ b/llamea/llamea.py
@@ -189,7 +189,7 @@ class LLaMEA:
             )
             HPO = False
         if role_prompt == "":
-            self.role_prompt = "You are a highly skilled computer scientist in the field of natural computing. Your task is to design novel metaheuristic algorithms to solve black box optimization problems."
+            self.role_prompt = "You are a highly skilled computer scientist and Python expert."
         if task_prompt == "":
             self.task_prompt = textwrap.dedent("""
                 The optimization algorithm should handle a wide range of tasks, which is evaluated on the BBOB test suite of 24 noiseless functions. Your task is to write the optimization algorithm in Python code to minimize the function value. The code should contain an `__init__(self, budget, dim)` function and the function `def __call__(self, func)`, which should optimize the black box function `func` using `self.budget` function evaluations.

--- a/llamea/llamea.py
+++ b/llamea/llamea.py
@@ -189,19 +189,24 @@ class LLaMEA:
             )
             HPO = False
         if role_prompt == "":
-            self.role_prompt = "You are a highly skilled computer scientist and Python expert."
+            self.role_prompt = (
+                "You are a highly skilled computer scientist and Python expert."
+            )
         if task_prompt == "":
-            self.task_prompt = textwrap.dedent("""
+            self.task_prompt = textwrap.dedent(
+                """
                 The optimization algorithm should handle a wide range of tasks, which is evaluated on the BBOB test suite of 24 noiseless functions. Your task is to write the optimization algorithm in Python code to minimize the function value. The code should contain an `__init__(self, budget, dim)` function and the function `def __call__(self, func)`, which should optimize the black box function `func` using `self.budget` function evaluations.
                 The func() can only be called as many times as the budget allows, not more. Each of the optimization functions has a search space between -5.0 (lower bound) and 5.0 (upper bound). The dimensionality can be varied.
 
                 Give an excellent and novel heuristic algorithm to solve this task.
-                """)
+                """
+            )
         else:
             self.task_prompt = task_prompt
 
         if example_prompt == None:
-            self.example_prompt = textwrap.dedent("""
+            self.example_prompt = textwrap.dedent(
+                """
                 An example of such code (a simple random search), is as follows:
                 ```
                 import numpy as np
@@ -224,21 +229,25 @@ class LLaMEA:
 
                         return self.f_opt, self.x_opt
                 ```
-                """)
+                """
+            )
         else:
             self.example_prompt = example_prompt
 
         if output_format_prompt is None:
-            self.output_format_prompt = textwrap.dedent("""
+            self.output_format_prompt = textwrap.dedent(
+                """
                 Provide the Python code and a one-line description with the main idea (without enters). Give the response in the format:
                 # Description: <short-description>
                 # Code:
                 ```python
                 <code>
                 ```
-                """)
+                """
+            )
             if HPO:
-                self.output_format_prompt = textwrap.dedent("""
+                self.output_format_prompt = textwrap.dedent(
+                    """
                     Provide the Python code, a one-line description with the main idea (without enters) and the SMAC3 Configuration space to optimize the code (in Python dictionary format). Give the response in the format:
                     # Description: <short-description>
                     # Code:
@@ -246,10 +255,12 @@ class LLaMEA:
                     <code>
                     ```
                     Space: <configuration_space>
-                    """)
+                    """
+                )
         else:
             self.output_format_prompt = output_format_prompt
-        self.diff_output_format_prompt = textwrap.dedent("""
+        self.diff_output_format_prompt = textwrap.dedent(
+            """
             ---
             You MUST use the exact SEARCH/REPLACE diff format shown below to indicate changes:
             ```
@@ -275,7 +286,8 @@ class LLaMEA:
                         C[i, j] += A[i, k] * B[k, j]
             >>>>>>> REPLACE
             ```
-            """)
+            """
+        )
         self.mutation_prompts = mutation_prompts
         self.adaptive_mutation = adaptive_mutation
         if mutation_prompts == None:

--- a/llamea/llamea.py
+++ b/llamea/llamea.py
@@ -11,6 +11,7 @@ import os
 import random
 import re
 import traceback
+import textwrap
 import warnings
 from typing import Callable, Optional
 import pickle
@@ -190,90 +191,91 @@ class LLaMEA:
         if role_prompt == "":
             self.role_prompt = "You are a highly skilled computer scientist in the field of natural computing. Your task is to design novel metaheuristic algorithms to solve black box optimization problems."
         if task_prompt == "":
-            self.task_prompt = """
-The optimization algorithm should handle a wide range of tasks, which is evaluated on the BBOB test suite of 24 noiseless functions. Your task is to write the optimization algorithm in Python code to minimize the function value. The code should contain an `__init__(self, budget, dim)` function and the function `def __call__(self, func)`, which should optimize the black box function `func` using `self.budget` function evaluations.
-The func() can only be called as many times as the budget allows, not more. Each of the optimization functions has a search space between -5.0 (lower bound) and 5.0 (upper bound). The dimensionality can be varied.
+            self.task_prompt = textwrap.dedent("""
+                The optimization algorithm should handle a wide range of tasks, which is evaluated on the BBOB test suite of 24 noiseless functions. Your task is to write the optimization algorithm in Python code to minimize the function value. The code should contain an `__init__(self, budget, dim)` function and the function `def __call__(self, func)`, which should optimize the black box function `func` using `self.budget` function evaluations.
+                The func() can only be called as many times as the budget allows, not more. Each of the optimization functions has a search space between -5.0 (lower bound) and 5.0 (upper bound). The dimensionality can be varied.
 
-Give an excellent and novel heuristic algorithm to solve this task.
-"""
+                Give an excellent and novel heuristic algorithm to solve this task.
+                """)
         else:
             self.task_prompt = task_prompt
 
         if example_prompt == None:
-            self.example_prompt = """
-An example of such code (a simple random search), is as follows:
-```
-import numpy as np
+            self.example_prompt = textwrap.dedent("""
+                An example of such code (a simple random search), is as follows:
+                ```
+                import numpy as np
 
-class RandomSearch:
-    def __init__(self, budget=10000, dim=10):
-        self.budget = budget
-        self.dim = dim
-        self.f_opt = np.inf
-        self.x_opt = None
+                class RandomSearch:
+                    def __init__(self, budget=10000, dim=10):
+                        self.budget = budget
+                        self.dim = dim
+                        self.f_opt = np.inf
+                        self.x_opt = None
 
-    def __call__(self, func):
-        for i in range(self.budget):
-            x = np.random.uniform(func.bounds.lb, func.bounds.ub)
+                    def __call__(self, func):
+                        for i in range(self.budget):
+                            x = np.random.uniform(func.bounds.lb, func.bounds.ub)
 
-            f = func(x)
-            if f < self.f_opt:
-                self.f_opt = f
-                self.x_opt = x
+                            f = func(x)
+                            if f < self.f_opt:
+                                self.f_opt = f
+                                self.x_opt = x
 
-        return self.f_opt, self.x_opt
-```
-"""
+                        return self.f_opt, self.x_opt
+                ```
+                """)
         else:
             self.example_prompt = example_prompt
 
         if output_format_prompt is None:
-            self.output_format_prompt = """
-Provide the Python code and a one-line description with the main idea (without enters). Give the response in the format:
-# Description: <short-description>
-# Code:
-```python
-<code>
-```
-"""
+            self.output_format_prompt = textwrap.dedent("""
+                Provide the Python code and a one-line description with the main idea (without enters). Give the response in the format:
+                # Description: <short-description>
+                # Code:
+                ```python
+                <code>
+                ```
+                """)
             if HPO:
-                self.output_format_prompt = """
-Provide the Python code, a one-line description with the main idea (without enters) and the SMAC3 Configuration space to optimize the code (in Python dictionary format). Give the response in the format:
-# Description: <short-description>
-# Code:
-```python
-<code>
-```
-Space: <configuration_space>"""
+                self.output_format_prompt = textwrap.dedent("""
+                    Provide the Python code, a one-line description with the main idea (without enters) and the SMAC3 Configuration space to optimize the code (in Python dictionary format). Give the response in the format:
+                    # Description: <short-description>
+                    # Code:
+                    ```python
+                    <code>
+                    ```
+                    Space: <configuration_space>
+                    """)
         else:
             self.output_format_prompt = output_format_prompt
-        self.diff_output_format_prompt = """
-        ---
-You MUST use the exact SEARCH/REPLACE diff format shown below to indicate changes:
-```
-<<<<<<< SEARCH
-# Original code to find and replace (must match exactly)
-=======
-# New replacement code
->>>>>>> REPLACE
-```
+        self.diff_output_format_prompt = textwrap.dedent("""
+            ---
+            You MUST use the exact SEARCH/REPLACE diff format shown below to indicate changes:
+            ```
+            <<<<<<< SEARCH
+            # Original code to find and replace (must match exactly)
+            =======
+            # New replacement code
+            >>>>>>> REPLACE
+            ```
 
-Example of valid diff format:
-```
-<<<<<<< SEARCH
-for i in range(m):
-    for j in range(p):
-        for k in range(n):
-            C[i, j] += A[i, k] * B[k, j]
-=======
-# Reorder loops for better memory access pattern
-for i in range(m):
-    for k in range(n):
-        for j in range(p):
-            C[i, j] += A[i, k] * B[k, j]
->>>>>>> REPLACE
-```
-"""
+            Example of valid diff format:
+            ```
+            <<<<<<< SEARCH
+            for i in range(m):
+                for j in range(p):
+                    for k in range(n):
+                        C[i, j] += A[i, k] * B[k, j]
+            =======
+            # Reorder loops for better memory access pattern
+            for i in range(m):
+                for k in range(n):
+                    for j in range(p):
+                        C[i, j] += A[i, k] * B[k, j]
+            >>>>>>> REPLACE
+            ```
+            """)
         self.mutation_prompts = mutation_prompts
         self.adaptive_mutation = adaptive_mutation
         if mutation_prompts == None:


### PR DESCRIPTION
Prevents accidental indentation from being sent to the LLM when
prompt strings are defined inside indented code blocks. Also fixes
a concrete bug in diff_output_format_prompt where the first content
line had 8 spurious leading spaces.

https://claude.ai/code/session_015FyjKEfZyut3DuZcKQNPQe